### PR TITLE
Fix Failure stringify() to use schema type

### DIFF
--- a/perl/lib/Data/Rx/Failure.pm
+++ b/perl/lib/Data/Rx/Failure.pm
@@ -111,7 +111,7 @@ sub stringify {
   my $struct = $self->struct;
 
   my $str = sprintf "Failed %s: %s (error: %s at %s)",
-    $self->error_types,
+    $struct->[0]{type},
     $struct->[0]{message},
     $self->error_string,
     $self->data_string;


### PR DESCRIPTION
Was using error types (e.g. Failed missing: ...) rather than schema type
(e.g. Failed //rec: ...).
