### PR TITLE
Data::Rx::Manual::CustomTypes pod and example/

### DIFF
--- a/perl/examples/Data/Rx/Type/CSV.pm
+++ b/perl/examples/Data/Rx/Type/CSV.pm
@@ -1,0 +1,60 @@
+use strict; use warnings;
+package Data::Rx::Type::CSV;
+use parent 'Data::Rx::CommonType::EasyNew';
+
+use String::Trim;
+
+use Carp ();
+
+sub type_uri {
+    'tag:codesimply.com,EXAMPLE:rx/csv',
+}
+
+sub guts_from_arg {
+    my ($class, $arg, $rx) = @_;
+
+    my $meta = $rx->make_schema({
+        type => '//rec',
+        required => {
+            # contents => '/.meta/schema', # not yet implemented, see http://rx.codesimply.com/moretypes.html
+            contents => '//any',
+        },
+        optional => {
+            trim => { 
+                # we don't just accept //bool as this only includes 'boolean' objects,
+                # let's also allow undef/0/1, as this is more Perlish!
+                type => '//any', 
+                of => [ '//nil', '//bool', '//int' ]
+            },
+        },
+    });
+
+    $meta->assert_valid($arg);
+
+    return {
+        trim => $arg->{trim},
+        str_schema => $rx->make_schema('//str'),
+        item_schema => $rx->make_schema( $arg->{contents} ),
+    };
+}
+
+sub assert_valid {
+    my ($self, $value) = @_;
+
+    $self->{str_schema}->assert_valid( $value );
+
+    my @values = split ',' => $value;
+
+    my $item_schema = $self->{item_schema};
+    my $trim = $self->{trim};
+
+    for my $subvalue (@values) {
+        trim($subvalue) if $trim;
+
+        $item_schema->assert_valid( $subvalue );
+    }
+
+    return 1;
+}
+
+1;

--- a/perl/examples/Data/Rx/Type/DateTime/W3.pm
+++ b/perl/examples/Data/Rx/Type/DateTime/W3.pm
@@ -1,0 +1,42 @@
+use strict; use warnings;
+
+package Data::Rx::Type::DateTime::W3;
+
+use parent 'Data::Rx::CommonType::EasyNew';
+use DateTime::Format::W3CDTF;
+
+use Carp ();
+
+sub type_uri {
+    'tag:codesimply.com,EXAMPLE:rx/datetime/w3',
+}
+
+sub guts_from_arg {
+    my ($class, $arg, $rx) = @_;
+    $arg ||= {};
+
+    if (my @unexpected = keys %$arg) {
+        Carp::croak sprintf "Unknown arguments %s in constructing %s",
+            (join ',' => @unexpected), $class->type_uri;
+    }
+
+    return {
+        dt => DateTime::Format::W3CDTF->new,
+    };
+}
+
+sub assert_valid {
+    my ($self, $value) = @_;
+
+    return 1 if $value && eval {
+        $self->{dt}->parse_datetime( $value  );
+    };
+
+    $self->fail({
+        error => [ qw(type) ],
+        message => "found value is not a w3 datetime",
+        value => $value,
+    })
+}
+
+1;

--- a/perl/examples/Data/Rx/Type/Enum.pm
+++ b/perl/examples/Data/Rx/Type/Enum.pm
@@ -1,0 +1,64 @@
+use strict; use warnings;
+
+package Data::Rx::Type::Enum;
+
+use parent 'Data::Rx::CommonType::EasyNew';
+
+use Carp ();
+
+sub type_uri {
+    'tag:codesimply.com,EXAMPLE:rx/enum',
+}
+
+sub guts_from_arg {
+    my ($class, $arg, $rx) = @_;
+
+    my $meta = $rx->make_schema({
+        type => '//rec',
+        required => {
+            contents => {
+                type => '//rec',
+                required => {
+                    type => '//str', # e.g. //int or //str.  Really we only
+                                     # want schemas that have a 'value' option
+                    values => {
+                        type => '//arr',
+                        contents => '//def', 
+                        # should be of type, as above, but we can't test this,
+                        # so we accept any defined value for now, and then test
+                        # the values below
+                    },
+                },
+            },
+        },
+    });
+
+    $meta->assert_valid( $arg );
+
+    my $type = $arg->{contents}{type};
+    my @values = @{ $arg->{contents}{values} };
+
+    # subsequent test that the provided values are acceptable
+    $rx->make_schema({ type => '//arr', contents => $type})->assert_valid( \@values );
+
+    my $schema = $rx->make_schema({
+        type => '//any',
+        of => [
+            map {
+                { type => $type, value => $_ }
+            } @values,
+        ]
+    });
+
+    return {
+        schema => $schema,
+    };
+}
+
+sub assert_valid {
+    my ($self, $value) = @_;
+
+    $self->{schema}->assert_valid( $value );
+}
+
+1;

--- a/perl/examples/test.pl
+++ b/perl/examples/test.pl
@@ -1,0 +1,136 @@
+use strict; use warnings;
+
+use Test::More;
+use Test::Exception;
+
+use FindBin;
+
+use lib "$FindBin::Bin";
+
+use Data::Rx;
+use Data::Rx::Type::DateTime::W3;
+use Data::Rx::Type::Enum;
+use Data::Rx::Type::CSV;
+
+my $rx = Data::Rx->new({
+    sort_keys => 1,
+    prefix => {
+        example => 'tag:codesimply.com,EXAMPLE:rx/',
+    },
+    type_plugins => [qw(
+        Data::Rx::Type::DateTime::W3
+        Data::Rx::Type::Enum
+        Data::Rx::Type::CSV
+    )],
+});
+
+subtest 'DateTime::W3' => sub {
+    dies_ok {
+        my $dt = $rx->make_schema({
+            type => '/example/datetime/w3',
+            zirble => 'fleem',
+        });
+    } 'Construction dies on extra arguments';
+
+    my $dt = $rx->make_schema({
+        type => '/example/datetime/w3',
+    });
+
+    ok ! $dt->check( undef ), 'Undef is not a valid string';
+    ok ! $dt->check( [] ),    'Reference is not a valid string';
+
+    ok ! $dt->check( '9th Feb 2012' ), 'invalid datetime format';
+
+    ok $dt->check( '1994-11-05T08:15:30-05:00' ), 'datetime format with offset';
+    ok $dt->check( '1994-11-05T08:15:30+05:00' ), 'datetime format with positive';
+    ok $dt->check( '1994-11-05T13:15:30Z' ),      'datetime format zulu';
+};
+
+subtest 'Enum' => sub {
+    dies_ok {
+        my $enum = $rx->make_schema({
+            type => '/example/enum',
+        });
+    } 'Construction dies on insufficient arguments';
+
+    dies_ok {
+        my $enum = $rx->make_schema({
+            type => '/example/enum',
+            contents => {
+                type => '//str',
+            },
+        });
+    } 'Construction dies on insufficient arguments';
+
+    dies_ok {
+        my $enum = $rx->make_schema({
+            type => '/example/enum',
+            contents => {
+                type => '//str',
+                values => [ 'foo', 'bar', 'baz' ],
+                bar => 'baz',
+            },
+        });
+    } 'Construction dies on extra arguments';
+
+    my $enum = $rx->make_schema({
+        type => '/example/enum',
+        contents => {
+            type => '//str',
+            values => [ 'foo', 'bar', 'baz' ],
+        },
+    });
+
+    ok ! $enum->check( undef ), 'Undef is not a valid string';
+    ok ! $enum->check( [] ),    'Reference is not a valid string';
+
+    ok ! $enum->check( 'fleem' ), 'not in enum';
+
+    ok $enum->check( 'foo' ), 'in enum';
+    ok $enum->check( 'bar' ), 'in enum';
+    ok $enum->check( 'baz' ), 'in enum';
+};
+
+subtest 'csv tests' => sub {
+
+    dies_ok {
+        my $csv = $rx->make_schema({
+            type => '/example/csv',
+        });
+    } 'Construction dies on no contents';
+
+    $rx->learn_type( 'tag:codesimply.com,EXAMPLE:rx/status' => {
+        type => '/example/enum',
+        contents => {
+            type => '//str',
+            values => ['open', 'closed'],
+        },
+    });
+
+    dies_ok {
+        my $csv = $rx->make_schema({
+            type => '/example/csv',
+            contents => '/example/status',
+            zirble => 'fleem',
+            roobit => [1,2],
+        });
+    } 'Construction dies on extra arguments';
+
+    my $csv = $rx->make_schema({
+        type => '/example/csv',
+        contents => '/example/status',
+        trim => 1,
+    });
+
+    ok ! $csv->check( undef ), 'Undef is not a valid string';
+    ok ! $csv->check( [] ),    'Reference is not a valid string';
+
+    ok ! $csv->check( 'zibble' ),      'invalid string';
+    ok ! $csv->check( 'open,zibble' ),  'an invalid element';
+
+    ok $csv->check( 'open' ),         'single value';
+    ok $csv->check( 'open,closed' ), 'multiple values ok';
+    ok $csv->check( 'open, closed ' ), 'spaces trimmed ok';
+};
+
+done_testing;

--- a/perl/lib/Data/Rx.pm
+++ b/perl/lib/Data/Rx.pm
@@ -30,6 +30,18 @@ use Data::Rx::TypeBundle::Core;
 
   die "invalid reply" unless $schema->check($reply);
 
+=head1 COMPLEX CHECKS
+
+Note that a "schema" can be represented either as a name or as a definition.
+In the L</SYNOPSIS> above, note that we have both, '//str' and 
+C<{ type =E<gt> '//int', value =E<gt> 201 }>.  
+With the L<collection types|http://rx.codesimply.com/coretypes.html#collect>
+provided by Rx, you can validate many complex structures.  See L</learn_types>
+for how to teach your Rx schema object about the new types you create.
+
+When required, see L<Data::Rx::Manual::CustomTypes> for details on creating a
+custom type plugin as a Perl module.
+
 =head1 SEE ALSO
 
 L<http://rjbs.manxome.org/rx>
@@ -64,7 +76,7 @@ Valid arguments are:
   prefix        - optional; a hashref of prefix pairs for type shorthand
   type_plugins  - optional; an arrayref of type or type bundle plugins
   no_core_types - optional; if true, core type bundle is not loaded
-  sort_keys     - optional; see L</sort_keys>
+  sort_keys     - optional; see the sort_keys section.
 
 The prefix hashref should look something like this:
 
@@ -102,8 +114,8 @@ sub new {
 
   my $schema = $rx->make_schema($schema);
 
-This returns a new schema checker (something with a C<check> method) for the
-given Rx input.
+This returns a new schema checker method for the given Rx input. This object
+will have C<check> and C<assert_valid> methods to test data with.
 
 =cut
 
@@ -142,7 +154,9 @@ sub make_schema {
 
 Given a type plugin, this registers the plugin with the Data::Rx object.
 Bundles are expanded recursively and all their plugins are registered.
+
 Type plugins must have a C<type_uri> method and a C<new_checker> method.
+See L<Data::Rx::Manual::CustomTypes> for details.
 
 =cut
 

--- a/perl/lib/Data/Rx/CommonType/EasyNew.pm
+++ b/perl/lib/Data/Rx/CommonType/EasyNew.pm
@@ -30,4 +30,12 @@ sub type { $_[0]->{_type} }
 
 sub rx { $_[0]->{_rx} }
 
+=pod
+
+=head1 NOTE
+
+For examples on how to subclass this, see L<Data::Rx::Manual::CustomTypes>.
+
+=cut
+
 1;

--- a/perl/lib/Data/Rx/Manual/CustomTypes.pod
+++ b/perl/lib/Data/Rx/Manual/CustomTypes.pod
@@ -1,0 +1,315 @@
+=pod
+
+=encoding UTF-8
+
+=head1 NAME
+
+Data::Rx::Manual::CustomTypes - overview of making new checkers
+
+=head1 OVERVIEW
+
+L<Data::Rx> ships with a variety of core validators -- 
+I<L<single|http://rx.codesimply.com/coretypes.html#single>>,
+I<L<collection|http://rx.codesimply.com/coretypes.html#collect>>, and 
+I<L<combination|http://rx.codesimply.com/coretypes.html#combo>> types, which can
+be combined in surprisingly powerful ways.  However the core language is
+deliberately limited to known cross-platform features, and there are things
+that you simply cannot represent with it. However, you can create custom I<type
+plugins> in any implementation, including L<Data::Rx> in Perl.
+
+=head1 SYNOPSIS
+
+The easiest way to create a custom type plugin is to subclass
+L<Data::Rx::CommonType::EasyNew>.
+
+    package My::Type::Foo;
+    use parent 'Data::Rx::CommonType::EasyNew';
+
+    sub type_uri {
+        'tag:example.com,EXAMPLE:rx/foo',
+    }
+
+    sub guts_from_arg {
+        my ($class, $arg, $rx) = @_;
+
+        # get and validate arguments from $arg
+
+        return {
+            # the "guts" for this object
+            # these might be validator objects using CPAN modules
+            # or using $rx->make_schema() etc.
+        },
+    }
+
+    sub assert_valid {
+        my ($self, $value) = @_;
+
+        # check the value, and either return 1 for success
+        # or die on failure
+    }
+
+    1;
+
+and later...
+
+    use Data::Rx;
+    use My::Type::Foo;
+
+    my $rx = Data::Rx->new({
+        sort_keys => 1,
+        prefix => {
+            example => 'tag:example.com,EXAMPLE:rx/',
+        },
+        type_plugins => [qw(
+            My::Type::Foo
+        )],
+    });
+
+    my $schema = $rx->make_schema('/example/foo');
+
+    $schema->assert_valid( $some_value );
+
+=head1 EXAMPLES
+
+These examples are worked fully in the C<examples/> directory.  In this man
+page, we will just look at interesting features of each type plugin, for clarity.
+
+=head2 W3C DateTime - using Perl and CPAN in checks
+
+We might want to validate dates in the W3CDTF format, which look like
+C<2003-02-15T13:50:05-05:00>.  We could of course write this with a
+regular expression, but let's take an even better approach and dash to the
+CPAN, where we find an existing module, L<DateTime::Format::W3CDTF>.
+
+Our parser, then, will instantiate one of these objects, and return it
+with C<guts_from_arg> to be stashed away.
+
+    use DateTime::Format::W3CDTF;
+
+    sub guts_from_arg {
+        my ($class, $arg, $rx) = @_;
+
+        return {
+            dt => DateTime::Format::W3CDTF->new,
+        };
+    }
+
+We can then test this in the C<assert_valid> routine by returning true
+if the date format matches:
+
+    sub assert_valid {
+        my ($self, $value) = @_;
+
+        return 1 if $value && eval {
+            $self->{dt}->parse_datetime( $value  );
+        };
+
+If it doesn't, then we should return an error, and to make sure that we
+act like a good citizen in the Rx ecosystem, let's use
+C<Data::Rx::CommonType::EasyNew>'s provided method C<fail>:
+
+        $self->fail({
+            error => [ qw(type) ],
+            message => "found value is not a w3 datetime",
+            value => $value,
+        })
+    }
+
+Now we can use this checker like so:
+
+    $rx->make_schema('/example/datetime/w3')
+        ->assert_valid( '2003-02-15T13:50:05-05:00' );
+
+=head2 Enum - delegate to another schema
+
+You'll often want to create data-types that match a set of values like
+(C<open>, C<closed>) or (C<0>, C<15>, C<30>, C<40>).  L<Data::Rx> doesn't
+have an Enum type, but it does have C<//any>:
+
+    {
+        type => '//any',
+        of => [
+            { type => '//str', value => 'open' },
+            { type => '//str', value => 'closed' },
+        ]
+    }
+
+This is a bit clumsy though, with the repetition of the type C<//str>.  Instead
+we would like an Enum type which might be declared like:
+
+    {
+        type => '/example/enum',
+        contents => {
+            type => '//str',
+            values => [ qw/
+                open
+                closed
+            /],
+        },
+    }
+
+Ignoring input checking (for this example), we can get this information from the
+C<$arg> parameter:
+
+    sub guts_from_arg {
+        my ($class, $arg, $rx) = @_;
+
+        my $type = $arg->{contents}{type};
+        my @values = @{ $arg->{contents}{values} };
+
+We already saw how we would write the enum as an C<//any> schema.  And in fact
+the easiest way to implement this type plugin is to do exactly that!  Let's
+create a schema which is equivalent, and return it, to be stashed in the object:
+
+        my $schema = $rx->make_schema({
+            type => '//any',
+            of => [
+                map {
+                    { type => $type, value => $_ }
+                } @values,
+            ]
+        });
+
+        return {
+            schema => $schema,
+        };
+    }
+
+Now, checking the enum is as simple as delegating to this schema:
+
+    sub assert_valid {
+        my ($self, $value) = @_;
+
+        $self->{schema}->assert_valid( $value );
+    }
+
+As we are delegating to another schema's C<assert_valid> we know that
+any exceptions will be in the correct format.  However, the error will
+be the one that C<//any> provides:
+
+    Failed //any: matched none of the available alternatives
+
+This is probably clear enough for an enum.  But we could improve this message
+by calling C<check> instead of C<assert_valid> and raising our own, nicely
+formatted, exception using C<fail>.
+
+=head2 CSV - delegation, checking input
+
+Some APIs like to specify a list of IDs or statuses not as an array (which
+of course Rx handles with C<//arr> but as a comma separated list.  Curses!
+
+We would like to write a type plugin that's defined something like:
+
+    {
+        type => '/example/csv',
+        contents => '/example/status',
+    }
+
+Of course now that we are getting data as strings, we also have to worry
+about spaces: e.g. in '123, 456', is the second ID ' 456' or just '456'?
+So let's also accept an optional 3rd parameter C<trim>.
+
+Now that we're asking for a more complex input data structure, let's validate
+it using Rx itself!
+
+    sub guts_from_arg {
+        my ($class, $arg, $rx) = @_;
+
+        my $meta = $rx->make_schema({
+            type => '//rec',
+            required => {
+                # contents => '/.meta/schema', # not yet implemented
+                contents => '//any',
+            },
+            optional => {
+                trim => { 
+                    # we don't just accept //bool as this only includes 'boolean' objects,
+                    # let's also allow undef/0/1, as this is more Perlish!
+                    type => '//any', 
+                    of => [ '//nil', '//bool', '//int' ]
+                },
+            },
+        });
+
+        $meta->assert_valid( $arg );
+
+The C<contents> argument is required, and should be a valid schema.  We've had
+to make a few trade-offs:
+
+=over 4
+
+=item *
+
+There isn't yet a convenient way to specify a schema, so we'll just accept
+C<//any> for now.  As we will then pass this result to C<make_schema> shortly,
+we will get a further validation of that in any case! (But see
+L<http://rx.codesimply.com/moretypes.html> for the full definition of a schema,
+if you prefer!)
+
+=item *
+
+Rx's type C<//bool> is deliberately targeted at JSON like boolean objects, so
+we'll also accept undef and 1 as "truthy" values.
+
+=back
+
+As we are expecting a comma separated I<string>, the first check we'll want to
+make is that the object we receive is in fact a string.  So the guts we'll
+return are:
+
+        return {
+            trim => $arg->{trim},
+            str_schema => $rx->make_schema('//str'),
+            item_schema => $rx->make_schema( $arg->{contents} ),
+        };
+
+Now our C<assert_valid> routine will use all of these pieces:
+
+    use String::Trim;
+
+    sub assert_valid {
+        my ($self, $value) = @_;
+
+First we check that we got a string:
+
+        $self->{str_schema}->assert_valid( $value );
+
+This means we can safely split the result:
+
+        my @values = split ',' => $value;
+
+        my $item_schema = $self->{item_schema};
+        my $trim = $self->{trim};
+
+For each result we trim (if requested) and use the supplied checker on each element.
+
+        for my $subvalue (@values) {
+            trim($subvalue) if $trim;
+
+            $item_schema->assert_valid( $subvalue );
+        }
+
+        return 1;
+    }
+
+Putting together all the pieces, we can call this like so:
+
+    my $csv = $rx->make_schema({
+        type => '/example/csv',
+        contents => {
+            type => '/example/enum',
+            contents => {
+                type => '//str',
+                values => [qw/ open closed /],
+            }
+        }
+        trim => 1,
+    });
+
+    $csv->assert_valid( 'open, closed' ); # OK!
+
+=head1 POD AUTHOR
+
+Hakim Cassimally <osfameron@cpan.org>
+
+=cut


### PR DESCRIPTION
"This documentation covers 3 worked examples showing different
facets on creating a type plugin.

The examples themselves are runnable, within the example/ directory
and come with a test.pl to demonstrate their use.

There are also some minor tweaks to the main Data::Rx documentation,
mostly to point at this new POD doc."

Unsure about a few bits for this contribution:
- I've not added the dependencies for examples/ to dist.ini (don't really know dzil, is there an ExamplesRequires plugin?)
- do I need to do anything with pod-weaving to add the additional section to Data::Rx itself?
- is the main Data::Rx::Manual::CustomTypes ok as a .pod like so, or does it require other config for the pod-weaving setup?

Shout if you'd like me to rework anything!
