### PR TITLE
overhaul python error reporting for structured failure

### DIFF
--- a/python/Rx.py
+++ b/python/Rx.py
@@ -150,7 +150,7 @@ class Factory(object):
     type_class = self.type_registry[uri]
 
     if isinstance(type_class, dict):
-      if not {'type'}.issuperset(schema.keys()):
+      if not {'type'}.issuperset(schema):
         raise SchemaError('composed type does not take check arguments');
       return self.make_schema(type_class['schema'])
     else:
@@ -162,7 +162,7 @@ class _CoreType(object):
     return 'tag:codesimply.com,2008:rx/core/' + self.subname()
 
   def __init__(self, schema, rx):
-    if not {'type'}.issuperset(schema.keys()):
+    if not {'type'}.issuperset(schema):
       raise SchemaError('unknown parameter for //{0}'.format(self.subname()))
 
   def check(self, value):
@@ -180,7 +180,7 @@ class AllType(_CoreType):
   def subname(): return 'all'
 
   def __init__(self, schema, rx):
-    if not {'type', 'of'}.issuperset(schema.keys()):
+    if not {'type', 'of'}.issuperset(schema):
       raise SchemaError('unknown parameter for //all')
     
     if not(schema.get('of') and len(schema.get('of'))):
@@ -211,7 +211,7 @@ class AnyType(_CoreType):
   def __init__(self, schema, rx):
     self.alts = None
 
-    if not {'type', 'of'}.issuperset(schema.keys()):
+    if not {'type', 'of'}.issuperset(schema):
       raise SchemaError('unknown parameter for //any')
     
     if schema.get('of') is not None:
@@ -242,7 +242,7 @@ class ArrType(_CoreType):
   def __init__(self, schema, rx):
     self.length = None
 
-    if not {'type', 'contents', 'length'}.issuperset(schema.keys()):
+    if not {'type', 'contents', 'length'}.issuperset(schema):
       raise SchemaError('unknown parameter for //arr')
 
     if not schema.get('contents'):
@@ -307,7 +307,7 @@ class IntType(_CoreType):
   def subname(): return 'int'
 
   def __init__(self, schema, rx):
-    if not {'type', 'range', 'value'}.issuperset(schema.keys()):
+    if not {'type', 'range', 'value'}.issuperset(schema):
       raise SchemaError('unknown parameter for //int')
 
     self.value = None
@@ -337,7 +337,7 @@ class MapType(_CoreType):
   def __init__(self, schema, rx):
     self.allowed = set()
 
-    if not {'type', 'values'}.issuperset(schema.keys()):
+    if not {'type', 'values'}.issuperset(schema):
       raise SchemaError('unknown parameter for //map')
 
     if not schema.get('values'):
@@ -380,7 +380,7 @@ class NumType(_CoreType):
   def subname(): return 'num'
 
   def __init__(self, schema, rx):
-    if not {'type', 'range', 'value'}.issuperset(schema.keys()):
+    if not {'type', 'range', 'value'}.issuperset(schema):
       raise SchemaError('unknown parameter for //num')
 
     self.value = None
@@ -417,7 +417,7 @@ class RecType(_CoreType):
   def subname(): return 'rec'
 
   def __init__(self, schema, rx):
-    if not {'type', 'rest', 'required', 'optional'}.issuperset(schema.keys()):
+    if not {'type', 'rest', 'required', 'optional'}.issuperset(schema):
       raise SchemaError('unknown parameter for //rec')
 
     self.known = set()
@@ -484,7 +484,7 @@ class SeqType(_CoreType):
   def subname(): return 'seq'
 
   def __init__(self, schema, rx):
-    if not {'type', 'contents', 'tail'}.issuperset(schema.keys()):
+    if not {'type', 'contents', 'tail'}.issuperset(schema):
       raise SchemaError('unknown parameter for //seq')
 
     if not schema.get('contents'):
@@ -530,7 +530,7 @@ class StrType(_CoreType):
   def subname(): return 'str'
 
   def __init__(self, schema, rx):
-    if not {'type', 'value', 'length'}.issuperset(schema.keys()):
+    if not {'type', 'value', 'length'}.issuperset(schema):
       raise SchemaError('unknown parameter for //str')
 
     self.value = None

--- a/python/Rx.py
+++ b/python/Rx.py
@@ -18,6 +18,9 @@ class SchemaValueMismatch(SchemaMismatch):
   def __init__(self, name, value):
     super().__init__('{0} must equal {1}'.format(name, value))
 
+class SchemaRangeMismatch(SchemaMismatch):
+  pass
+
 def indent(text, level=1, whitespace='  '):
     return '\n'.join(whitespace*level+line for line in text.split('\n'))
 
@@ -57,7 +60,7 @@ class Util(object):
         range_str = ''
         if r.get('min', nan) == r.get('max', nan):
           msg = '{0} must equal {1}'.format(name, r['min'])
-          raise SchemaMismatch(msg)
+          raise SchemaRangeMismatch(msg)
 
         if 'min' in r:
           range_str = '[{0}, '.format(r['min'])
@@ -73,7 +76,7 @@ class Util(object):
         else:
           range_str += 'inf)'
 
-        raise SchemaMismatch(name+' must be in range '+range_str)
+        raise SchemaRangeMismatch(name+' must be in range '+range_str)
 
     return validate_range
 

--- a/python/Rx.py
+++ b/python/Rx.py
@@ -216,7 +216,7 @@ class AnyType(_CoreType):
     if not {'type', 'of'}.issuperset(schema):
       raise SchemaError('unknown parameter for //any')
     
-    if schema.get('of') is not None:
+    if 'of' in schema:
       if not schema['of']: raise SchemaError('no alternatives given in //any of')
       self.alts = [ rx.make_schema(alt) for alt in schema['of'] ]
 

--- a/python/Rx.py
+++ b/python/Rx.py
@@ -211,7 +211,7 @@ class Factory(object):
     else:
       return type_class(schema, self)
 
-### Core Type Abstract Class -------------------------------------------------
+### Core Type Base Class -------------------------------------------------
 
 class _CoreType(object):
   @classmethod

--- a/python/Rx.py
+++ b/python/Rx.py
@@ -327,7 +327,7 @@ class IntType(_CoreType):
       raise SchemaTypeMismatch(name,'integer')
 
     if self.range:
-      self.range(value, 'name')
+      self.range(value, name)
 
     if self.value is not None and value != self.value:
       raise SchemaValueMismatch(name, self.value)

--- a/python/Rx.py
+++ b/python/Rx.py
@@ -1,6 +1,8 @@
 import re
+from six import string_types # for 2-3 compatibility
 import types
 from numbers import Number
+
 
 core_types = [ ]
 
@@ -12,11 +14,11 @@ class SchemaMismatch(Exception):
 
 class SchemaTypeMismatch(SchemaMismatch):
   def __init__(self, name, desired_type):
-    super().__init__('{0} must be {1}'.format(name, desired_type))
+    SchemaMismatch.__init__(self, '{0} must be {1}'.format(name, desired_type))
 
 class SchemaValueMismatch(SchemaMismatch):
   def __init__(self, name, value):
-    super().__init__('{0} must equal {1}'.format(name, value))
+    SchemaMismatch.__init__(self, '{0} must equal {1}'.format(name, value))
 
 class SchemaRangeMismatch(SchemaMismatch):
   pass
@@ -137,7 +139,7 @@ class Factory(object):
     self.type_registry[uri] = { 'schema': schema }
 
   def make_schema(self, schema):
-    if isinstance(schema, str):
+    if isinstance(schema, string_types):
       schema = { 'type': schema }
 
     if not isinstance(schema, dict):
@@ -409,7 +411,7 @@ class OneType(_CoreType):
   def subname(): return 'one'
 
   def validate(self, value, name='value'):
-    if not isinstance(value, (Number, str)):
+    if not isinstance(value, (Number, string_types)):
       raise SchemaTypeMismatch(name, 'number or string')
 
 class RecType(_CoreType):
@@ -535,7 +537,7 @@ class StrType(_CoreType):
 
     self.value = None
     if 'value' in schema:
-      if not isinstance(schema['value'], str):
+      if not isinstance(schema['value'], string_types):
         raise SchemaError('invalid value parameter for //str')
       self.value = schema['value']
 
@@ -544,7 +546,7 @@ class StrType(_CoreType):
       self.length = Util.make_range_validator(schema['length'])
 
   def validate(self, value, name='value'):
-    if not isinstance(value, str):
+    if not isinstance(value, string_types):
       raise SchemaTypeMismatch(name, 'string')
     if self.value is not None and value != self.value:
       raise SchemaValueMismatch(name, '"{0}"'.format(self.value))

--- a/python/Rx.py
+++ b/python/Rx.py
@@ -283,7 +283,7 @@ class BoolType(_CoreType):
   def subname(): return 'bool'
 
   def validate(self, value, name='value'):
-    if not (isinstance(value, bool)):
+    if not isinstance(value, bool):
       raise SchemaTypeMismatch(name, 'boolean')
 
 class DefType(_CoreType):

--- a/python/Rx.py
+++ b/python/Rx.py
@@ -101,20 +101,20 @@ class Factory(object):
     m = re.match('^/([-._a-z0-9]*)/([-._a-z0-9]+)$', type_name)
 
     if not m:
-      raise ValueError("couldn't understand type name '%s'" % type_name)
+      raise ValueError("couldn't understand type name '{0}'".format(type_name))
 
     prefix, suffix = m.groups()
 
     if prefix not in self.prefix_registry:
       raise KeyError(
-        "unknown prefix '%s' in type name '%s'" % (prefix, type_name)
+        "unknown prefix '{0}' in type name '{1}'".format(prefix, type_name)
       )
 
     return self.prefix_registry[ prefix ] + suffix
 
   def add_prefix(self, name, base):
     if self.prefix_registry.get(name):
-      raise SchemaError("the prefix '%s' is already registered" % name)
+      raise SchemaError("the prefix '{0}' is already registered".format(name))
 
     self.prefix_registry[name] = base;
 
@@ -122,13 +122,13 @@ class Factory(object):
     t_uri = t.uri()
 
     if t_uri in self.type_registry:
-      raise ValueError("type already registered for " + t_uri)
+      raise ValueError("type already registered for {0}".format(t_uri))
 
     self.type_registry[t_uri] = t
 
   def learn_type(self, uri, schema):
     if self.type_registry.get(uri):
-      raise SchemaError("tried to learn type for already-registered uri %s" % uri)
+      raise SchemaError("tried to learn type for already-registered uri {0}".format(uri))
 
     # make sure schema is valid
     # should this be in a try/except?
@@ -145,7 +145,7 @@ class Factory(object):
 
     uri = self.expand_uri(schema['type'])
 
-    if not self.type_registry.get(uri): raise SchemaError("unknown type %s" % uri)
+    if not self.type_registry.get(uri): raise SchemaError("unknown type {0}".format(uri))
 
     type_class = self.type_registry[uri]
 
@@ -163,7 +163,7 @@ class _CoreType(object):
 
   def __init__(self, schema, rx):
     if not {'type'}.issuperset(schema.keys()):
-      raise SchemaError('unknown parameter for //%s' % self.subname())
+      raise SchemaError('unknown parameter for //{0}'.format(self.subname()))
 
   def check(self, value):
     try:

--- a/python/Rx.py
+++ b/python/Rx.py
@@ -3,10 +3,9 @@ from six import string_types # for 2-3 compatibility
 import types
 from numbers import Number
 
-import pdb # debug only
+#import pdb # debug only
 
-# TODO: test the new updates to this system
-# TODO: write a whole new goddamn test suite for these structured errors
+# possible TODO: write a whole new test suite for these structured errors
 core_types = [ ]
 
 ### Exception Classes --------------------------------------------------------

--- a/python/Rx.py
+++ b/python/Rx.py
@@ -37,8 +37,9 @@ class Util(object):
 
     return check_range
 
+  @staticmethod
   def make_range_validator(opt):
-    check_range = make_range_check(opt)
+    check_range = Util.make_range_check(opt)
 
     r = opt.copy()
     nan = float('nan')
@@ -47,7 +48,8 @@ class Util(object):
       if not check_range(value):
         range_str = ''
         if r.get('min', nan) == r.get('max', nan):
-          raise SchemaMismatch(name+' must equal '+r['min'])
+          msg = '{0} must equal {1}'.format(name, r['min'])
+          raise SchemaMismatch(msg)
 
         if 'min' in r:
           range_str = '[{0}, '.format(r['min'])
@@ -64,6 +66,8 @@ class Util(object):
           range_str += 'inf)'
 
         raise SchemaMismatch(name+' must be in range '+range_str)
+
+    return validate_range
 
 
 class Factory(object):

--- a/python/Rx.py
+++ b/python/Rx.py
@@ -88,12 +88,14 @@ class Factory(object):
     if not m:
       raise ValueError("couldn't understand type name '%s'" % type_name)
 
-    if not self.prefix_registry.get(m.group(1)):
-      raise ValueError(
-        "unknown prefix '%s' in type name '%s'" % (m.group(1), type_name)
+    prefix, suffix = m.groups()
+
+    if prefix not in self.prefix_registry:
+      raise KeyError(
+        "unknown prefix '%s' in type name '%s'" % (prefix, type_name)
       )
 
-    return '%s%s' % (self.prefix_registry[ m.group(1) ], m.group(2))
+    return self.prefix_registry[ prefix ] + suffix
 
   def add_prefix(self, name, base):
     if self.prefix_registry.get(name):
@@ -104,8 +106,8 @@ class Factory(object):
   def register_type(self, t):
     t_uri = t.uri()
 
-    if self.type_registry.get(t_uri):
-      raise ValueError("type already registered for %s" % t_uri)
+    if t_uri in self.type_registry:
+      raise ValueError("type already registered for " + t_uri)
 
     self.type_registry[t_uri] = t
 

--- a/python/Rx.py
+++ b/python/Rx.py
@@ -276,7 +276,7 @@ class IntType(_CoreType):
       raise SchemaMismatch(name+' not in range')
 
     if self.value is not None and value != self.value:
-      raise SchemaMismatch(name+' must be '+str(self.value))
+      raise SchemaMismatch(name+' must equal '+str(self.value))
 
 class MapType(_CoreType):
   @staticmethod
@@ -349,7 +349,7 @@ class NumType(_CoreType):
       raise SchemaMismatch(name+' not in range')
 
     if self.value is not None and value != self.value:
-      raise SchemaMismatch(name+' must be '+str(self.value))
+      raise SchemaMismatch(name+' must equal '+str(self.value))
 
 class OneType(_CoreType):
   @staticmethod
@@ -385,7 +385,7 @@ class RecType(_CoreType):
 
   def validate(self, value, name='object'):
     if not isinstance(value, dict):
-      raise SchemaMismatch(name+' must be a record (dictionary/associative array)')
+      raise SchemaMismatch(name+' must be a record')
 
     unknown = [k for k in value.keys() if k not in self.known]
 
@@ -446,10 +446,10 @@ class SeqType(_CoreType):
       raise SchemaMismatch(name+' must be a sequence')
 
     if len(value) < len(self.content_schema):
-      return SchemaMismatch(name+' is less than expected length')
+      raise SchemaMismatch(name+' is less than expected length')
 
     if len(value) > len(self.content_schema) and not self.tail_schema:
-      return SchemaMismatch(name+' exceeds expected length')
+      raise SchemaMismatch(name+' exceeds expected length')
 
     error_messages = []
 
@@ -490,7 +490,7 @@ class StrType(_CoreType):
     if not isinstance(value, str):
       raise SchemaMismatch(name+' must be a string')
     if self.value is not None and value != self.value:
-      raise SchemaMismatch(name+" must be '{0}'".format(self.value))
+      raise SchemaMismatch(name+" must have value '{0}'".format(self.value))
     if self.length is not None and not self.length(len(value)):
       raise SchemaMismatch(name+' is not in expected length range')
 

--- a/python/Rx.py
+++ b/python/Rx.py
@@ -26,6 +26,7 @@ class Util(object):
 
     r = opt.copy()
     inf = float('inf')
+
     def check_range(value):
       return(
         r.get('min',    -inf) <= value and \
@@ -41,6 +42,7 @@ class Util(object):
 
     r = opt.copy()
     nan = float('nan')
+
     def validate_range(value, name='value'):
       if not check_range(value):
         range_str = ''
@@ -177,11 +179,13 @@ class AllType(_CoreType):
       except SchemaMismatch as e:
         error_messages.append(str(e))
 
-    if error_messages:
+    if len(error_messages) > 1:
       messages = indent('\n'.join(error_messages))
       message = '{0} failed to meet all schema requirements:\n{1}'
       message = message.format(name, messages)
       raise SchemaMismatch(message)
+    elif len(error_messages) == 1:
+      raise SchemaMismatch(error_messages[0])
 
 class AnyType(_CoreType):
   @staticmethod
@@ -237,7 +241,7 @@ class ArrType(_CoreType):
       raise SchemaMismatch(name+' must be an array.')
 
     if self.length:
-      self.length(len(value), 'length of '+name)
+      self.length(len(value), name+' length')
 
     error_messages = []
 
@@ -247,11 +251,13 @@ class ArrType(_CoreType):
       except SchemaMismatch as e:
         error_messages.append(str(e))
 
-    if error_messages:
+    if len(error_messages) > 1:
       messages = indent('\n'.join(error_messages))
       message = '{0} sequence contains invalid elements:\n{1}'
       message = message.format(name, messages)
       raise SchemaMismatch(message)
+    elif len(error_messages) == 1:
+      raise SchemaMismatch(name+': '+error_messages[0])
 
 class BoolType(_CoreType):
   @staticmethod
@@ -334,12 +340,13 @@ class MapType(_CoreType):
       except SchemaMismatch as e:
         error_messages.append(str(e))
 
-    if error_messages:
+    if len(error_messages) > 1:
       messages = indent('\n'.join(error_messages))
       message = '{0} map contains invalid entries:\n{1}'
       message = message.format(name, messages)
       raise SchemaMismatch(message)
-
+    elif len(error_messages) == 1:
+      raise SchemaMismatch(name+': '+error_messages[0])
 
 class NilType(_CoreType):
   @staticmethod
@@ -446,11 +453,13 @@ class RecType(_CoreType):
       except SchemaMismatch as e:
         error_messages.append(str(e))
 
-    if error_messages:
+    if len(error_messages) > 1:
       messages = indent('\n'.join(error_messages))
       message = '{0} record is invalid:\n{1}'
       message = message.format(name, messages)
       raise SchemaMismatch(message)
+    elif len(error_messages) == 1:
+      raise SchemaMismatch(name+': '+error_messages[0])
 
 
 class SeqType(_CoreType):
@@ -488,11 +497,13 @@ class SeqType(_CoreType):
       except SchemaMismatch as e:
         error_messages.append(str(e))   
 
-    if error_messages:
+    if len(error_messages) > 1:
       messages = indent('\n'.join(error_messages))
       message = '{0} sequence is invalid:\n{1}'
       message = message.format(name, messages)
-      raise SchemaMismatch(message)     
+      raise SchemaMismatch(message)
+    elif len(error_messages) == 1:
+      raise SchemaMismatch(name+': '+error_messages[0])
 
     if len(value) > len(self.content_schema):
       self.tail_schema.validate(value[len(self.content_schema):], name)
@@ -521,7 +532,7 @@ class StrType(_CoreType):
     if self.value is not None and value != self.value:
       raise SchemaMismatch(name+" must have value '{0}'".format(self.value))
     if self.length:
-      self.length(len(value), 'length of '+name)
+      self.length(len(value), name+' length')
 
 core_types = [
   AllType,  AnyType, ArrType, BoolType, DefType,

--- a/python/Rx.py
+++ b/python/Rx.py
@@ -59,11 +59,11 @@ class Util(object):
 
     def validate_range(value, name='value'):
       if not check_range(value):
-        range_str = ''
         if r.get('min', nan) == r.get('max', nan):
           msg = '{0} must equal {1}'.format(name, r['min'])
           raise SchemaRangeMismatch(msg)
-
+        
+        range_str = ''
         if 'min' in r:
           range_str = '[{0}, '.format(r['min'])
         elif 'min-ex' in r:

--- a/python/rx-test.py
+++ b/python/rx-test.py
@@ -6,7 +6,6 @@ import pdb
 import os
 
 plan(None)
-os.chdir('..')
 rx = Rx.Factory({ "register_core_types": True });
 
 isa_ok(rx, Rx.Factory)

--- a/python/rx-test.py
+++ b/python/rx-test.py
@@ -110,13 +110,23 @@ for schema_name in schema_names:
       # if to_test == '*': to_test = test_data[ source ].keys()
 
       for entry in to_test:
-        result = schema.check( test_data[source][entry] )
+        result = None
+        try:
+          schema.validate(test_data[source][entry])
+          result = True
+        except Rx.SchemaMismatch as e:
+          print(str(e))
+          result = False
 
         desc = "%s/%s against %s" % (source, entry, schema_name)
 
         if pf == 'pass':
           ok(result, "VALID  : %s" % desc)
-          if not result: pdb.set_trace()
+          #if not result:
+          #  pdb.set_trace()
+          #  result = schema.check( test_data[source][entry] )
         else:
           ok(not result, "INVALID: %s" % desc)
-          if result: pdb.set_trace()
+          #if result:
+          #  pdb.set_trace()
+          #  result = schema.check( test_data[source][entry] )

--- a/python/rx-test.py
+++ b/python/rx-test.py
@@ -114,7 +114,6 @@ for schema_name in schema_names:
           schema.validate(test_data[source][entry])
           result = True
         except Rx.SchemaMismatch as e:
-          print(str(e))
           result = False
 
         desc = "%s/%s against %s" % (source, entry, schema_name)


### PR DESCRIPTION
For my own project, I have updated Rx.py to be compatible with both Python 2 and 3. I have also rewritten a lot of the code to be slightly more concise/modern/pythonic.

The other major feature is that the types' `check()` methods now have an augmented version called `validate()`, which instead of simply returning `True` or `False`, raises a `SchemaMismatch` exception with an informative error message when the value doesn't match the schema.

I've also changed the behavior of `Factory.__init__()` to register core types automatically, and take `register_core_types` as a boolean argument instead of as a key in a dictionary. I am unsure why this argument was a dictionary in the first place, and what this afforded the user, so this may be a change worth reverting.
